### PR TITLE
Fix variable name field filled by default

### DIFF
--- a/Default.sublime-settings
+++ b/Default.sublime-settings
@@ -9,6 +9,9 @@
 	// use golangconfig, if false then shellenv will be used to get golang environment variables
 	"gorename_use_golangconfig": false,
 
+	// fill variable name text field by default
+	"gorename_autofill": false,
+
 	// The output can either be one of: 'buffer', 'output_panel'
 	// Buffers can hold results from more than one invocation
 	// Output panels sit underneath the editor area and are easily dismissed

--- a/goRename.py
+++ b/goRename.py
@@ -184,8 +184,11 @@ class GoRenameCommand(sublime_plugin.TextCommand):
                 v = not v
             if flag_opt != -1:
                 pop_menu()
-            else: 
-                self.view.window().show_input_panel('GoRename: rename "%s" (from line %s) to' % (word, line_number), word, rename_name_input, on_change=None, on_cancel=None)
+            else:
+                varName = ''
+                if get_setting("gorename_autofill", False):
+                    varName = word
+                self.view.window().show_input_panel('GoRename: rename "%s" (from line %s) to' % (word, line_number), varName, rename_name_input, on_change=None, on_cancel=None)
 
         def pop_menu():
             self.view.show_popup_menu(compile_flags(), popup_menu_callback)

--- a/goRename.py
+++ b/goRename.py
@@ -185,7 +185,7 @@ class GoRenameCommand(sublime_plugin.TextCommand):
             if flag_opt != -1:
                 pop_menu()
             else: 
-                self.view.window().show_input_panel('GoRename: rename "%s" (from line %s) to' % (word, line_number), '', rename_name_input, on_change=None, on_cancel=None)
+                self.view.window().show_input_panel('GoRename: rename "%s" (from line %s) to' % (word, line_number), word, rename_name_input, on_change=None, on_cancel=None)
 
         def pop_menu():
             self.view.show_popup_menu(compile_flags(), popup_menu_callback)


### PR DESCRIPTION
Most of time I just need to quickly change variable name instead of typing whole new phrase or copy and paste old name. With this fix GoRename variable name field is filled by default.
