### PR TITLE
Fix normalize path Windows support

### DIFF
--- a/goRename.py
+++ b/goRename.py
@@ -293,7 +293,7 @@ class GoRenameCommand(sublime_plugin.TextCommand):
         # Build gorename cmd.
         cmd = "%(toolpath)s -offset %(file_path)s:%(pos)s -to %(name)s %(flags)s" % {
         "toolpath": toolpath,
-        "file_path": cmd_quote(os.path.realpath(file_path)),
+        "file_path": cmd_quote(os.path.realpath(file_path)).replace('\'', '\"'),
         "pos": pos,
         "name": name,
         "flags": flags} 


### PR DESCRIPTION
I found out that shlex.quote() normalized path is not working on Windows because of single quotes. After this little fix plugin works both on Linux and Windows.
