### PR TITLE
Some code cleanup of normalize path fix

### DIFF
--- a/goRename.py
+++ b/goRename.py
@@ -12,11 +12,6 @@ go get -u golang.org/x/tools/cmd/gorename
 
 import sublime, sublime_plugin, subprocess, time, re, os, subprocess, sys, time, hashlib
 
-try:
-    from shlex import quote as cmd_quote
-except ImportError:
-    from pipes import quote as cmd_quote
-
 DEBUG = False
 VERSION = ''
 use_golangconfig = False
@@ -291,9 +286,9 @@ class GoRenameCommand(sublime_plugin.TextCommand):
             gorename_json = "-json"
 
         # Build gorename cmd.
-        cmd = "%(toolpath)s -offset %(file_path)s:%(pos)s -to %(name)s %(flags)s" % {
+        cmd = "%(toolpath)s -offset \"%(file_path)s:%(pos)s\" -to %(name)s %(flags)s" % {
         "toolpath": toolpath,
-        "file_path": cmd_quote(os.path.realpath(file_path)).replace('\'', '\"'),
+        "file_path": os.path.realpath(file_path),
         "pos": pos,
         "name": name,
         "flags": flags} 


### PR DESCRIPTION
I found shlex.quote() source code and discovered that shlex.quote() only puts single quotes in double quotes and then whole string in single quotes, it doesn't escape anything:

```
def quote(s):
    """Return a shell-escaped version of the string *s*."""
    if not s:
        return "''"
    if _find_unsafe(s) is None:
        return s

    # use single quotes, and put single quotes into double quotes
    # the string $'b is then quoted as '$'"'"'b'
    return "'" + s.replace("'", "'\"'\"'") + "'"
```

so it is not needed at all as the single quotes are replaced with double quotes in the end anyway. I did some code cleanup and replaced shlex.quote() with just double quotes in command line and everything works like before (both on Linux and Windows). Sorry for problem, but I didn't have much time for research. Cheers!
